### PR TITLE
Check for gpu hardware continually.

### DIFF
--- a/reactive/cuda.sh
+++ b/reactive/cuda.sh
@@ -198,7 +198,7 @@ EOF
     fi
 }
 
-@only_once
+@when_not 'cuda.supported'
 function check_cuda_support() {
     case "${SUPPORT_CUDA}" in
         "0" )


### PR DESCRIPTION
Instead of checking for gpus only once, check on every hook
invocation, or until cuda support is detected.

This change allows the layer to install cuda packages when gpu
hardware is added to an already-running unit. Before, since the
check was run only_once, the gpus had to be present at the time
the install hook was executed.