### PR TITLE
remove the -x to decrease debug output

### DIFF
--- a/reactive/cuda.sh
+++ b/reactive/cuda.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 source charms.reactive.sh
 


### PR DESCRIPTION
I'm getting oodles of noise from the nvidia-cuda layer in my debug-log:

```
2017-07-11 15:39:24 INFO config-changed Running reactive_handler_main for cuda.sh (test)
2017-07-11 15:39:25 INFO config-changed Will invoke: check_cuda_support
2017-07-11 15:39:25 INFO config-changed End reactive_handler_main (test)
2017-07-11 15:39:25 INFO juju-log Invoking reactive handler: reactive/cuda.sh "b'check_cuda_support\n'"
2017-07-11 15:39:25 INFO config-changed + source charms.reactive.sh
2017-07-11 15:39:25 INFO config-changed ++ awk 'BEGIN{FS="-"}{print $1}'
2017-07-11 15:39:25 INFO config-changed ++ config-get cuda-version
2017-07-11 15:39:25 INFO config-changed + CUDA_VERSION=8.0.61
2017-07-11 15:39:25 INFO config-changed ++ awk 'BEGIN{FS="-"}{print $2}'
2017-07-11 15:39:25 INFO config-changed ++ config-get cuda-version
2017-07-11 15:39:25 INFO config-changed + CUDA_SUB_VERSION=1
2017-07-11 15:39:25 INFO config-changed + LAYER_BLACKLIST_CONF=/etc/modprobe.d/blacklist-layer-nvidia-cuda.conf
2017-07-11 15:39:25 INFO config-changed + LAYER_LD_CONF=/etc/ld.so.conf.d/layer-nvidia-cuda.conf
2017-07-11 15:39:25 INFO config-changed + LAYER_PROFILE_CONF=/etc/profile.d/layer-nvidia-cuda.sh
2017-07-11 15:39:25 INFO config-changed + LAYER_RC_CONF=/home/ubuntu/.bashrc
2017-07-11 15:39:25 INFO config-changed + ROOT_URL=http://developer.download.nvidia.com/compute/cuda/repos
2017-07-11 15:39:25 INFO config-changed ++ wc -l
2017-07-11 15:39:25 INFO config-changed ++ grep -iA2 NVIDIA
2017-07-11 15:39:25 INFO config-changed ++ lspci -nnk
2017-07-11 15:39:25 INFO config-changed + SUPPORT_CUDA=0
...
```

I feel as though this layer is solid enough to remove the `-x`.