### PR TITLE
Ignore held packages when apt removing old nvidia/cuda packages

### DIFF
--- a/reactive/cuda.sh
+++ b/reactive/cuda.sh
@@ -96,7 +96,14 @@ EOF
 #####################################################################
 
 function all:all:install_nvidia_driver() {
-    apt-get remove -yqq --purge nvidia-* libcuda1-*
+    ##remove any nvidia-* or libcuda1-* packages that aren't held
+    ## the nvidia-docker binary needs to held to resist this
+    ## but the awk means apt will play nicely with that
+    PCKGS=`dpkg -l | awk '$2~/^nvidia-/|| $2~/^libcuda1-/{if($1!~/^h/){printf " "$2}}'`
+    if [ -n "$PCKGS" ]; then
+        juju-log "removing $PCKGS"
+        apt-get remove --ignore-hold -yqq --purge $PCKGS
+    fi
     apt-get install -yqq --no-install-recommends \
         nvidia-375 \
         nvidia-375-dev \


### PR DESCRIPTION
Before installing nvidia-375 nvidia-375-dev libcuda1-375  the charm issues a apt remove nvidia* which can catch other, unintended, packages in its blast radius, especially nvidia-docker2, nvidia-container-runtime  etc etc as installed by layer-docker.  This remove fails because layer-docker sets its packages as "hold" and if they weren't it would break layer-docker. This change simply filters held packages out of the list to be removed, which avoids the issue.