### PR TITLE
fix broken symlinks

### DIFF
--- a/reactive/cuda.sh
+++ b/reactive/cuda.sh
@@ -238,10 +238,12 @@ function all::all::add_cuda_path() {
     # NB: fix "cannot find -lnvcuvid" when linking cuda programs
     # see: https://devtalk.nvidia.com/default/topic/769578/cuda-setup-and-installation/cuda-6-5-cannot-find-lnvcuvid/2
     if [ ! -f /usr/lib/libnvcuvid.so.1 ]; then
-        ln -s /usr/lib/nvidia-*/libnvcuvid.so.1 /usr/lib/libnvcuvid.so.1
+        LINK_SRC=$(find /usr/lib/nvidia-* -name libnvcuvid.so.1 -print -quit)
+        ln -s ${LINK_SRC} /usr/lib/libnvcuvid.so.1
     fi
     if [ ! -f /usr/lib/libnvcuvid.so ]; then
-        ln -s /usr/lib/nvidia-*/libnvcuvid.so /usr/lib/libnvcuvid.so
+        LINK_SRC=$(find /usr/lib/nvidia-* -name libnvcuvid.so -print -quit)
+        ln -s ${LINK_SRC} /usr/lib/libnvcuvid.so
     fi
 }
 

--- a/reactive/cuda.sh
+++ b/reactive/cuda.sh
@@ -238,10 +238,10 @@ function all::all::add_cuda_path() {
     # NB: fix "cannot find -lnvcuvid" when linking cuda programs
     # see: https://devtalk.nvidia.com/default/topic/769578/cuda-setup-and-installation/cuda-6-5-cannot-find-lnvcuvid/2
     if [ ! -f /usr/lib/libnvcuvid.so.1 ]; then
-        ln -s /usr/lib/nvidia-375/libnvcuvid.so.1 /usr/lib/libnvcuvid.so.1
+        ln -s /usr/lib/nvidia-*/libnvcuvid.so.1 /usr/lib/libnvcuvid.so.1
     fi
     if [ ! -f /usr/lib/libnvcuvid.so ]; then
-        ln -s /usr/lib/nvidia-375/libnvcuvid.so /usr/lib/libnvcuvid.so
+        ln -s /usr/lib/nvidia-*/libnvcuvid.so /usr/lib/libnvcuvid.so
     fi
 }
 


### PR DESCRIPTION
First of all, why are there no Issues for this repo!??!!

Secondly, we were hard coding symlinks in `/usr/lib` that pointed to `nvidia-375`. This is bad because the nvidia repository now installs `nvidia-390` (remember this layer installs the latest deps regardless of the `cuda-version` setting).

This caused broken symlinks like this:

```bash
ubuntu@ip-172-31-93-15:~$ ll /usr/lib/libnvcuvid*
lrwxrwxrwx 1 root root      33 Mar 16 22:57 /usr/lib/libnvcuvid.so -> /usr/lib/nvidia-375/libnvcuvid.so
lrwxrwxrwx 1 root root      35 Mar 16 22:57 /usr/lib/libnvcuvid.so.1 -> /usr/lib/nvidia-375/libnvcuvid.so.1
```

You can't see that those are red, but they are.  See how there are no `/usr/lib/nvidia-375` dirs -- the appropriate libs are actually in `nvidia-390`:

```bash
ubuntu@ip-172-31-93-15:~$ ll /usr/lib/nvidia-*/libnvcuvid*
lrwxrwxrwx 1 root root      15 Feb  1 03:46 /usr/lib/nvidia-390/libnvcuvid.so -> libnvcuvid.so.1
lrwxrwxrwx 1 root root      20 Feb  1 03:46 /usr/lib/nvidia-390/libnvcuvid.so.1 -> libnvcuvid.so.390.30
-rw-r--r-- 1 root root 2477360 Feb  1 06:50 /usr/lib/nvidia-390/libnvcuvid.so.390.30
```

This PR uses a wildcard to find our symlink source.  It seems safe enough (i haven't seen a case where we have multiple `nvidia-*` directories), and in the worst case, it returns the first lib found -- if that's wrong, it's no worse than the guaranteed broken symlink we have today.

This tested well on a p2.xlarge in AWS.