### PR TITLE
update to cuda 9.x (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nvidia CUDA Layer
 
-Installs CUDA 8.0.61-1 and Nvidia 375 drivers when supported GPU hardware is
-detected.
+Installs the configured CUDA version with Nvidia drivers when supported GPU
+hardware is detected.
 
 
 # States
@@ -34,13 +34,13 @@ The following runtime configuration options are available in this layer:
 
 * `cuda-version`
 
-  The `cuda-repo` package version to install. Defaults to `8.0.61-1`.
+  The `cuda-repo` package version to install. Defaults to `9.1.85-1`.
 
-      juju config <charm> cuda-version=8.0.61-1
+      juju config <charm> cuda-version=9.1.85-1
 
-  >**Note**: Regardless of this setting, the `cuda` meta package will install
-  the latest dependencies available in the repository. It is therefore
-  recommended to set this to the most recent `cuda-repo` version.
+  >**Note**: This layer constructs a `major-minor` string from this value and
+  installs the corresponding `cuda-x-y` meta package (`cuda-9-1` by default).
+  This package will install the latest available dependencies in this series.
 
 * `install-cuda`
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,10 @@
 options:
   cuda-version:
     type: string
-    default: "8.0.61-1"
+    default: "9.1.85-1"
     description: |
-      The cuda-repo package version to install.
+      Version of the cuda-repo deb to install. Valid options can be found at:
+      http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64
   install-cuda:
     type: boolean
     default: True


### PR DESCRIPTION
- change default version to latest cuda-repo pkg from nvidia (9.1.85-1)
- refactor the install_nvidia_driver as purge_nvidia_driver
  - we do not need to install the nvidia driver anymore since the cuda
    meta package will pull in cuda-drivers, which does the right thing.
  - instead, purge any existing nvidia pkgs that are not held so the
    subsequent meta package installation puts all the right bits down.
- add the apt key in case it doesnt exist already
  - cuda 8.x does this automatically in the cuda-repo postinst
  - cuda 9.x does not
  - it does not hurt to run apt-key adv even if the key already exists
- install 'cuda-$VER' instead of 'cuda'
  - with the latter, we would always get the very latest cuda packages
  - using the specific cuda-$VER metapackage lets the user track the
    major-minor version they want.